### PR TITLE
update pointing_device_task_combined_kb to return pointing_device_task_combined_user 

### DIFF
--- a/keyboards/cyboard/cyboard.c
+++ b/keyboards/cyboard/cyboard.c
@@ -244,7 +244,7 @@ static void pointing_device_task_charybdis(report_mouse_t* mouse_report, bool is
 report_mouse_t pointing_device_task_combined_kb(report_mouse_t left_report, report_mouse_t right_report) {
         pointing_device_task_charybdis(&left_report, true);
         pointing_device_task_charybdis(&right_report, false);
-    return pointing_device_combine_reports(left_report, right_report);
+    return pointing_device_task_combined_user(left_report, right_report);
 }
 
 #    if defined(POINTING_DEVICE_ENABLE) && !defined(NO_CHARYBDIS_KEYCODES)


### PR DESCRIPTION
Update pointing_device_task_combined_kb in cyboard.c to return the _user method. 

This follows the [recommended approach](https://github.com/qmk/qmk_firmware/blob/master/docs/custom_quantum_functions.md#a-word-on-core-vs-keyboards-vs-keymap-a-word-on-core-vs-keyboards-vs-keymap) to using quantum functions and lets the user override in their keymap. I've been using this on my personal board almost since I got it.

You can see how this gets called [here](https://github.com/Cyboard-DigitalTailor/vial-qmk/blob/5c357a39fc480574739c805ee009b45facdd4cee/quantum/pointing_device/pointing_device.c#L489C1-L518C7) - it should behave exactly the same as the old code if the user doesn't have a keymap with that method.

(I deleted the old PR by accident - sorry).